### PR TITLE
rrdtool generates images using stdout 

### DIFF
--- a/qml/GraphList.qml
+++ b/qml/GraphList.qml
@@ -26,6 +26,7 @@ PagePL {
                 property int myCallbackId: -1
                 property bool update_skipped_since_invisible: false
                 property int myHeight: 0
+                property int imageIndex: -1
 
                 source: ""
 
@@ -39,7 +40,7 @@ PagePL {
                             myCallbackId = appWindow.getCallbackId()
 
                         grapher.getImage(myCallbackId, graphDefs.plots[index].type, settings.timewindow_from, settings.timewindow_duration,
-                                         Qt.size(width,settings.graph_base_height), false, source )
+                                         Qt.size(width,settings.graph_base_height), false, imageIndex )
                     }
                 }
 
@@ -56,13 +57,14 @@ PagePL {
                     onNewImage: {
                         if (imageFor == image.myCallbackId)
                         {
-                            // console.log("Image received: ", imageFor, fname)
+                            console.log("Image received: ", imageFor, iIndex)
                             image.source = fname
+                            image.imageIndex = iIndex
 
-                            var sh = image.sourceSize.height
+                            var sh = iRealSize.height
                             if (image.myHeight != sh)
                             {
-                                //console.log("Changing height " + imageFor + ": " + image.myHeight + " -> " + sh)
+                                console.log("Changing height " + imageFor + ": " + image.myHeight + " -> " + sh)
                                 image.myHeight = sh
                                 graphHeightCache[index] = sh
                             }
@@ -71,8 +73,8 @@ PagePL {
                             else indicator.visible = false
 
                             // ask for new image if the width doesn't match
-                            if (image.sourceSize.width != width) {
-                                // console.log("onNI: " + graphDefs.plots[index].type + " width difference " + width + " " + image.sourceSize.width)
+                            if (iRealSize.width != width) {
+                                console.log("onNI: " + graphDefs.plots[index].type + " width difference " + width + " " + iRealSize.width)
                                 image.askImage()
                             }
                         }

--- a/qml/Platform.silica/ApplicationWindowPL.qml
+++ b/qml/Platform.silica/ApplicationWindowPL.qml
@@ -95,25 +95,65 @@ ApplicationWindow {
     //
     Rectangle {
         id: progress
+        property int progHeight: Math.max(3, Screen.height*0.0075)
+        property double currentProgress: 0.0
 
         z: 100
-        anchors.top: pageStack.top
-        anchors.left: pageStack.left
+        x: 0
+        y: 0
 
-        height: Math.max(5, Screen.height*0.0075)
-        width: pageStack.width
+        height: 0
+        width: 0
         color: "steelblue"
-        visible: true
+        visible: false
+
+        function changeSize(sz)
+        {
+            currentProgress = sz
+            drawBar()
+        }
+
+        function drawBar()
+        {
+            if (appWindowBase.orientation == Orientation.Portrait) {
+                x = 0
+                y = 0
+                height = progHeight
+                width = Screen.width * currentProgress
+            }
+            else if (appWindowBase.orientation == Orientation.Landscape) {
+                x = Screen.width - progHeight
+                y = 0
+                height = Screen.height * currentProgress
+                width = progHeight
+            }
+            else if (appWindowBase.orientation == Orientation.PortraitInverted) {
+                height = progHeight
+                width = Screen.width * currentProgress
+                x = Screen.width - width
+                y = Screen.height - height
+            }
+            else if (appWindowBase.orientation == Orientation.LandscapeInverted) {
+                height = Screen.height * currentProgress
+                width = progHeight
+                x = 0
+                y = Screen.height - height
+            }
+        }
+    }
+
+    onOrientationChanged: {
+        progress.drawBar()
     }
 
     function getProgressFullWidth()
     {
-        return pageStack.width
+        return 1.0
     }
 
     function setProgressState(visible, width)
     {
-        progress.width = width
+        progress.changeSize(width)
         progress.visible = visible
     }
 

--- a/src/graphgenerator.h
+++ b/src/graphgenerator.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QProcess>
 #include <QDir>
-#include <QTemporaryDir>
 #include <QSize>
 #include <QHash>
 #include <QColor>
@@ -66,13 +65,13 @@ public:
     ///
     /// @param caller QML Image Id of the calling QML object. When image is ready, this Id would be used in emitted signal
     ///
-    Q_INVOKABLE void getImage(int caller, QString plot_type, double from, double duration, QSize size, bool full_size, QString current_fname);
+    Q_INVOKABLE void getImage(int caller, QString plot_type, double from, double duration, QSize size, bool full_size, int current_id);
 
 signals:
     void readyChanged();
     void progressChanged();
     void errorRRDTool(QString error_text);
-    void newImage( int imageFor, QString fname); ///< Emitted when new image has been generated
+    void newImage(int imageFor, QByteArray fname, int iIndex, QSize iRealSize); ///< Emitted when new image has been generated
 
 public slots:
 
@@ -88,9 +87,9 @@ protected:
 
     /// \brief Called when image is ready as a callback function
     ///
-    void imageCallback(int tocall, QString fname, QSize size, QString id);
+    void imageCallback(int tocall, int index, QSize size, QSize real_size, QString id);
 
-    void imageSizeTypeCallback(QString size_key, QString fname,
+    void imageSizeTypeCallback(QString size_key,
                                // the followin options are an arguments for getImage
                                int caller, QString type, double from, double duration,
                                QSize size, bool full_size);
@@ -99,7 +98,6 @@ protected:
 
 protected:
     QDir m_current_dir;                             ///< Current working directory
-    QTemporaryDir m_dir;                            ///< Directory holding images
     QHash< QString, ImageFile > m_image_cache;      ///< Image cache
 
     QHash< QString, QString > m_image_types;        ///< Image type -> command map
@@ -111,12 +109,12 @@ protected:
     bool m_ready = false;
     bool m_rrdtool_busy = false;
 
-    QString m_rrdtool_output;
+    QByteArray m_rrdtool_output;
     CommandQueue m_command_queue;
     Command m_command_current;
     //int m_rrdtool_output_skip_lines = 0;
 
-    size_t m_next_image_index = 0;
+    int m_next_image_index = 0;
 
     double m_timeout = 120; ///< Time to keep images in cache
     //int m_timer_id = 0;

--- a/src/imagefile.cpp
+++ b/src/imagefile.cpp
@@ -5,34 +5,11 @@
 
 using namespace Graph;
 
-size_t Graph::ImageFile::total_size = 0;
-
-void ImageFile::deleteFile()
+void ImageFile::setImage(QByteArray fname, QSize req_size, QSize real_size, int id)
 {
-    if ( m_filename.length() == 0 ) return;
-
-    total_size -= m_size;
-    m_size = 0;
-
-    QFileInfo info(m_filename);
-    if (info.exists())
-        QFile::remove(m_filename);
-}
-
-
-void ImageFile::setImage(QString fname, QSize imsize)
-{
-    deleteFile(); // cleanup
-
     m_filename = fname;
-    m_image_size = imsize;
-
-    QFileInfo info(m_filename);
-    if (info.exists())
-    {
-        m_size = info.size();
-        total_size += m_size;
-    }
-
+    m_req_size = req_size;
+    m_real_size = real_size;
+    m_id = id;
     m_time = QDateTime::currentDateTimeUtc();
 }

--- a/src/imagefile.h
+++ b/src/imagefile.h
@@ -1,14 +1,14 @@
 #ifndef IMAGEFILE_H
 #define IMAGEFILE_H
 
-#include <QString>
+#include <QByteArray>
 #include <QDateTime>
 #include <QSize>
 
 namespace Graph
 {
 
-/// \brief Image file tracking objeck
+/// \brief Image file tracking object
 ///
 /// Allows access to the image file name, its size, and deletes the image
 /// file on destruction. No copy operator or constructor are allowed - it has to be
@@ -16,32 +16,27 @@ namespace Graph
 ///
 class ImageFile
 {
-protected:
-    static size_t total_size;
-
-public:
-    static size_t getTotalSize() { return total_size; }                           ///< Size of all currently held image files in bytes
-
 public:
 
     ImageFile() {}
-    ~ImageFile() { deleteFile(); }
+    ~ImageFile() { }
 
-    void setImage(QString fname, QSize imsize);                                 ///< Sets a new file to track
+    void setImage(QByteArray fname, QSize req_size, QSize real_size, int id);                                 ///< Sets a new file to track
 
-    size_t getSize() const { return m_size; }                                      ///< Size of the tracked file
-    QString getFilename() const { return m_filename; }                             ///< Tracked filename
-    QSize getImageSize() const { return m_image_size; }
+    int getId() const { return m_id; }
+    QByteArray getFilename() const { return m_filename; }                             ///< Tracked filename
+    QSize getImageReqSize() const { return m_req_size; }
+    QSize getImageRealSize() const { return m_real_size; }
     double secsTo(const QDateTime &other) const { return m_time.secsTo(other); }   ///< Number of seconds from registration of the file to other
 
 protected:
-    void deleteFile();
 
 protected:
-    QString m_filename;
+    QByteArray m_filename;
     QDateTime m_time;
-    size_t m_size = 0;
-    QSize m_image_size;
+    QSize m_req_size;
+    QSize m_real_size;
+    int m_id = -5;
 };
 
 }


### PR DESCRIPTION
Images are propagated through data:image/png,base64 URL to QML. When compared to reading them into QImage in C++ and then using Qt Image Provider facility, this approach results in smaller memory footprint. In addition, progress bar enhancements were made.
