### PR TITLE
do not downscale cpu to millipercent

### DIFF
--- a/tools/systemdatascope-makeconfig
+++ b/tools/systemdatascope-makeconfig
@@ -1331,7 +1331,7 @@ if os.path.exists( "processes" ) or os.path.exists( "load" ):
                 s = StackOrLines( cs, "Processes/"+procname, name,
                                   Title = title_start + gethuman("Processes/"+name),
                                   HeadSize = gethead("Processes/"+name),
-                                  extra_command = '--lower-limit 0',
+                                  extra_command = '--lower-limit 0 --upper-limit 1',
                                   Unit = u,
                                   minmax=True )
 


### PR DESCRIPTION
Currently the process CPU graphs show millipercent values for CPU time < 1%. This gives a false/confusing visual impression how much a process with low usage consumes.

This clamps the limit to 1.0 so graphs are more comparable.